### PR TITLE
Async profiler: CPU vs IO example.

### DIFF
--- a/src/clojure_experiments/books/joy_of_clojure/ch15_performance.clj
+++ b/src/clojure_experiments/books/joy_of_clojure/ch15_performance.clj
@@ -343,7 +343,7 @@
     (if (>= 1 x) acc (recur (dec x) (* x acc)))))
 (time (dotimes [_ 1e5]
         (factorial-c 20)))
-;; "Elapsed time: 27.574799 msecs"
+;; "Elapsed time: 27.574799 msecs" ; OUTDATED!
 
 ;; Let's try "unchecked math" as the final optimization
 ;; - UPDATE: with clojure 1.11 and CLJ-2670 (use Math.*Exact methods)

--- a/src/clojure_experiments/performance/performance.clj
+++ b/src/clojure_experiments/performance/performance.clj
@@ -3,8 +3,7 @@
             [clj-java-decompiler.core :as decompiler :refer [decompile disassemble]]
             [no.disassemble :as nd]
             [criterium.core :as crit]
-            [clj-java-decompiler.core :refer [decompile disassemble] :as decompiler]
-            ))
+            [clj-java-decompiler.core :refer [decompile disassemble] :as decompiler]))
 
 ;;; Boxed math
 
@@ -28,6 +27,37 @@
     (while (< (/ (- (System/nanoTime) start) 1e9) secs)
       (test-sum)
       (test-div))))
+
+;; Let's demonstrate how CPU profiling can yield a misleading profile
+;; in terms of where the real bottleneck is.
+;; Here, CPU-expensive operations consume about 2 seconds
+;; while Network IO about 10 seconds
+(comment
+
+  (defn- network-call []
+    (apply str (take 15 (slurp "https://idnes.cz"))))
+
+  ;; it's about 150 msecs on my machine/network in Brno, CZ
+  (time (network-call ))
+  ;; "Elapsed time: 159.988287 msecs"
+
+
+  (time (prof/profile {:width 2400 :return-file true}
+                      (print "waiting for cpu: ")
+                      (time (burn-cpu 1))
+
+                      (print "waiting for Network IO: ")
+                      (time (dotimes [_ 50] (network-call)))
+
+                      (print "waiting for cpu: ")
+                      (time (burn-cpu 1))))
+  ;; waiting for cpu: "Elapsed time: 1001.41616 msecs"
+  ;; waiting for Network IO: "Elapsed time: 10125.600056 msecs"
+  ;; waiting for cpu: "Elapsed time: 1001.359411 msecs"
+  ;; "Elapsed time: 12708.13256 msecs"
+  .)
+
+
 (comment
 
   (prof/start {})
@@ -64,11 +94,14 @@
 ;;; http://clojure-goes-fast.com/blog/clj-async-profiler-040/
 (comment
   ;; division will be slowest because of Ratios
-  (prof/profile {:width 2400}
+  (prof/profile {:width 2400 :return-file true}
    (dotimes [_ 10] (reduce + (range 10000000)))
    (dotimes [_ 10] (reduce / (range 10000000)))
    (dotimes [_ 10] (reduce * (range 10000000))))
 
+  (prof/profile {:width 2400 :return-file true}
+                (Thread/sleep 200))
+  
 
   ;; profile external process
   (def pid 64735)

--- a/src/clojure_experiments/performance/performance.clj
+++ b/src/clojure_experiments/performance/performance.clj
@@ -42,7 +42,9 @@
   ;; "Elapsed time: 159.988287 msecs"
 
 
-  (time (prof/profile {:width 2400 :return-file true}
+  (time (prof/profile {:width 2400 :return-file true
+                       ;; try wall-clock profiling to get more accurate picture: https://github.com/jvm-profiling-tools/async-profiler#wall-clock-profiling
+                       #_#_:event :wall}
                       (print "waiting for cpu: ")
                       (time (burn-cpu 1))
 


### PR DESCRIPTION
By default, Async profiler does (on-)CPU profiling
so it cannot construct a proper profile for threads blocked on IO.

We demonstrate this by trying a bunch of network calls that take about 10 seconds
and also doing some CPU intensive operations for 2 seconds.
The resulting profile is misleading because it shows that the major part
is actually `burn-cpu` while it's less than 20% of the total running time.

## The profiling code: 

```
  (time (prof/profile {:width 2400 :return-file true}
                      (print "waiting for cpu: ")
                      (time (burn-cpu 1))

                      (print "waiting for Network IO: ")
                      (time (dotimes [_ 50] (network-call)))

                      (print "waiting for cpu: ")
                      (time (burn-cpu 1))))
  ;; waiting for cpu: "Elapsed time: 1001.41616 msecs"
  ;; waiting for Network IO: "Elapsed time: 10125.600056 msecs"
  ;; waiting for cpu: "Elapsed time: 1001.359411 msecs"
  ;; "Elapsed time: 12708.13256 msecs"
```

## The flamegraph

Notice that it reports `14.89%` for `burn-cpu`
and only `9.49%` for the network calls.

![image](https://user-images.githubusercontent.com/1083629/174742501-d8cb78b0-8ad3-48f2-84c9-1a324265c974.png)

![image](https://user-images.githubusercontent.com/1083629/174742536-d436bc7f-ce91-414c-a87b-9b70bf1a7428.png)


It's even worse when we reduce the number of network calls so they take only about 4.5 seconds (while burn-cpu still executes for 2 seconds wall-clock time) - 24.88% vs 3.32%

![image](https://user-images.githubusercontent.com/1083629/174743243-08f80442-2c4c-451d-897b-272e1b30455c.png)


## Wall-clock profiling

If we use wall-clock profiling the picture is more accurate (but it's harder to find our particular thread of execution):

```
(time (prof/profile {:width 2400 :return-file true
                       ;; try wall-clock profiling to get more accurate picture: https://github.com/jvm-profiling-tools/async-profiler#wall-clock-profiling
                       :event :wall}
                      (print "waiting for cpu: ")
                      (time (burn-cpu 1))

                      (print "waiting for Network IO: ")
                      (time (dotimes [_ 50] (network-call)))

                      (print "waiting for cpu: ")
                      (time (burn-cpu 1))))
```

![image](https://user-images.githubusercontent.com/1083629/174744617-4ee2d34c-41f9-49d3-9a54-4b02a030e7e8.png)

