### PR TITLE
Clarify difference between checked and unchecked match in Clojure 1.11.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,6 @@
 {:deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        ;; try older clojure version if you wish
+        ;; org.clojure/clojure {:mvn/version "1.10.3"}
         org.clojure/test.check {:mvn/version "1.1.0"}
         com.gfredericks/test.chuck {:mvn/version "0.2.12"}
         medley/medley {:mvn/version "1.3.0"}

--- a/src/clojure_experiments/books/joy_of_clojure/ch15_performance.clj
+++ b/src/clojure_experiments/books/joy_of_clojure/ch15_performance.clj
@@ -343,7 +343,10 @@
     (if (>= 1 x) acc (recur (dec x) (* x acc)))))
 (time (dotimes [_ 1e5]
         (factorial-c 20)))
-;; "Elapsed time: 27.574799 msecs" ; OUTDATED!
+;; OUTDATED! see https://clojure.atlassian.net/browse/CLJ-2670
+;; - with Clojure 1.11, all but the very first run are about 7 msecs!
+;; - with Clojure 1.10.3 they are about 25 msecs!
+;; "Elapsed time: 27.574799 msecs"
 
 ;; Let's try "unchecked math" as the final optimization
 ;; - UPDATE: with clojure 1.11 and CLJ-2670 (use Math.*Exact methods)


### PR DESCRIPTION
There's almost no difference anymore it seems.
Unchecked math used to be much faster (as I learned in Joy of Clojure, p. 376)
but that was before Clojure 1.11 and https://clojure.atlassian.net/browse/CLJ-2670 in particular.