### PR TITLE
Add example with tricky auto-gensym behavior.

### DIFF
--- a/src/clojure_experiments/records.clj
+++ b/src/clojure_experiments/records.clj
@@ -19,3 +19,20 @@
 
 (.__extmap big-john)
 ;; => {:middle-name "Big"}
+
+
+;;; defrecord's method bodies are _not_ closures! https://clojuredocs.org/clojure.core/defrecord
+;;; > Note that method bodies are not closures,
+;;; > the local environment includes only the named fields,
+;;; > and those fields can be accessed directly.
+(defrecord simple [s]
+  clojure.lang.IFn
+  (invoke [this] (str "I'm crazy: " s)))
+
+(def ss (->simple "ahoj"))
+
+(ss)
+;; => "I'm crazy: ahoj"
+
+((assoc ss :s "hello"))
+;; => "I'm crazy: hello"


### PR DESCRIPTION
`recursive-macro-1` repeats the last element instead of building a vector of all the elements.

```
(defmacro recursive-macro-1 [[x & more :as xs] acc]
  (if (seq xs)
    `(let [x# ~x] ; DOES NOT WORK as expected!
       (recursive-macro-1 ~more (conj ~acc x#)))
    acc))

  (recursive-macro-1 [1 2] []) ;; => [2 2]

;; auto-gensym
(let [x__10885__auto__ 1]
  (recursive-macro-1 (2) (conj [] x__10885__auto__)))
;; macroexpand-all
(let*
    [x__10885__auto__ 1]
  (let*
      [x__10885__auto__ 2]
    (conj (conj [] x__10885__auto__) x__10885__auto__)))
```

TODO: Watch this Ask clojure question: https://ask.clojure.org/index.php/12012/auto-gensym-in-recursive-macros