### PR TITLE
Experiment with deftype memory layout.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -105,7 +105,7 @@
         ;; blazing fast JSON & CSV parsing: https://github.com/cnuernber/charred
         com.cnuernber/charred {:mvn/version "1.000"}
         ;; clerk - notebooks: https://github.com/nextjournal/clerk
-        io.github.nextjournal/clerk {:mvn/version "0.5.346"}
+        io.github.nextjournal/clerk {:mvn/version "0.8.451"}
         ;; meta-csv, next.jdbc, and docjure are used in data-science notebook: https://github.com/nextjournal/clerk-demo/blob/main/notebooks/data_science.clj
         meta-csv/meta-csv {:mvn/version "0.1.0"}
         com.github.seancorfield/next.jdbc  {:mvn/version "1.2.659"}

--- a/src/clojure_experiments/collections.clj
+++ b/src/clojure_experiments/collections.clj
@@ -566,3 +566,15 @@ db
 ;; => ({:x 1, :foo 42, :bar 43} {:x 2, :foo 999})
 
 
+
+
+(def ^:private old-trend [{:date "2020-02-19" :value :no-conflict}
+                          {:date "2020-02-20" :value :oldest-duplicate}
+                          {:date "2020-02-20" :value :newer-duplicate}])
+
+(medley.core/distinct-by :date old-trend)
+;; => ({:date "2020-02-19", :value :no-conflict}
+;; =>  {:date "2020-02-20", :value :oldest-duplicate})
+
+
+(map last (partition-by :date old-trend))

--- a/src/clojure_experiments/experiments.clj
+++ b/src/clojure_experiments/experiments.clj
@@ -918,42 +918,6 @@ d-m
 #_(alias 'superx 'not.exist) ;=> no namespace found
 
 
-;;; Profile with tufte: https://github.com/ptaoussanis/tufte#how-does-tufte-compare-to-hugoduncancriterium
-
-(require '[taoensso.tufte :as tufte :refer (defnp p profiled profile)])
-(comment
-  ;; We'll request to send `profile` stats to `println`:
-  (tufte/add-basic-println-handler! {})
-
-;;; Let's define a couple dummy fns to simulate doing some expensive work
-  (defn get-x [] (Thread/sleep 500)             "x val")
-  (defn get-y [] (Thread/sleep (rand-int 1000)) "y val")
-
-  ;; How do these fns perform? Let's check:
-  (profile ; Profile any `p` forms called during body execution
-   {} ; Profiling options; we'll use the defaults for now
-   (dotimes [_ 5]
-     (p :get-x (get-x))
-     (p :get-y (get-y)))))
-
-
-(comment 
-
-  (defmacro protocol [name & body]
-    `(defn [command]
-       (condp = command
-         body)))
-
-  (protocol cmds
-            "LIST" (list-handler)
-            "EXIT" (exit-handler))
-
-  (defn cmds [command]
-    (condp = command
-      "LIST" (list-handler)
-      "EXIT" (exit-handler))))
-
-
 
 ;;; https://stackoverflow.com/questions/50663848/converting-string-to-nested-map-in-clojure
 (def my-file "1|apple|sweet

--- a/src/clojure_experiments/performance/tufte.clj
+++ b/src/clojure_experiments/performance/tufte.clj
@@ -1,0 +1,47 @@
+(ns clojure-experiments.performance.tufte
+  "Some 'performance logging' with tufte: https://github.com/ptaoussanis/tufte
+  See also https://cuddly-octo-palm-tree.com/posts/2022-01-23-opt-clj-2/"
+  (:require [taoensso.tufte :refer [defnp p profiled profile] :as tufte]))
+
+
+;;; Profile with tufte: https://github.com/ptaoussanis/tufte#how-does-tufte-compare-to-hugoduncancriterium
+
+
+(comment
+  ;; We'll request to send `profile` stats to `println`:
+  (tufte/add-basic-println-handler! {})
+
+;;; Let's define a couple dummy fns to simulate doing some expensive work
+  (defn get-x [] (Thread/sleep 500)             "x val")
+  (defn get-y [] (Thread/sleep (long (rand-int 1000))) "y val")
+
+
+  ;; with simple cider profiling: `cider-profile-ns-toggle` and `cider-profile-summary`
+  (dotimes [_ 5]
+    (p :get-x (get-x))
+    (p :get-y (get-y)))
+  ;; |                                         :name | :n | :sum |   :q1 |  :med |   :q3 |   :sd |  :mad |
+  ;; |-----------------------------------------------+----+------+-------+-------+-------+-------+-------|
+  ;; | #'clojure-experiments.performance.tufte/get-x |  5 | 2.5s | 503ms | 504ms | 504ms |   1ms | 847µs |
+  ;; | #'clojure-experiments.performance.tufte/get-y |  5 | 2.6s | 355ms | 499ms | 499ms | 319ms | 223ms |
+
+
+  ;; With tufte - notice that it's nicer because it contains more statistics and also percentages
+  ;; - but you have to manually instrument it :(
+  (profile ; Profile any `p` forms called during body execution
+   {} ; Profiling options; we'll use the defaults for now
+   (dotimes [_ 5]
+     (p :get-x (get-x))
+     (p :get-y (get-y))))
+
+  ;; pId           nCalls        Min      50% ≤      90% ≤      95% ≤      99% ≤        Max       Mean   MAD      Clock  Total
+
+  ;; :get-y             5    78.23ms   849.94ms   991.97ms   991.97ms   991.97ms   991.97ms   669.73ms  ±48%     3.35s     57%
+  ;; :get-x             5   500.31ms   502.48ms   504.45ms   504.45ms   504.45ms   504.45ms   502.28ms   ±0%     2.51s     43%
+
+  ;; Accounted                                                                                                   5.86s    100%
+  ;; Clock                                                                                                       5.86s    100%
+
+
+  .)
+


### PR DESCRIPTION
Based on https://www.reddit.com/r/Clojure/comments/vmul4a/help_with_jvm_memory_optimization/

Strangely, it seems that primitive longs occupy more space than objects,
but that's the case only for small integers (due to integer caching):

```

  ;; now try 1 million of items - primitives, surprisingly, occupy more space!!!
  (print-memory-layout (coll-of-size 1000000))
  ;; java.util.ArrayList@46beede9d footprint:
  ;;      COUNT       AVG       SUM   DESCRIPTION
  ;;          1   4861968   4861968   [Ljava.lang.Object;
  ;;    1000000        24  24000000   clojure_experiments.performance.memory.SomeType
  ;;          1        24        24   java.util.ArrayList
  ;;    1000002            28861992   (total) ; ~28 MB vs ~20MB for Longs!!!

  ;; allocated-bytes reports quite a bit more than 28MB
  (allocated-bytes (fn [] (coll-of-size 1000000)))
  ;; => 62608176

  ;; ... and back to Longs -> it now stays stable!
  (deftype SomeType [a])
  (print-memory-layout (coll-of-size 1000000))
  ;; java.util.ArrayList@4790011d footprint:
  ;;      COUNT       AVG       SUM   DESCRIPTION
  ;;          1   4861968   4861968   [Ljava.lang.Object;
  ;;    1000000        16  16000000   clojure_experiments.performance.memory.SomeType
  ;;        100        24      2400   java.lang.Long
  ;;          1        24        24   java.util.ArrayList
  ;;    1000102            20864392   (total) ; just ~20MB vs ~28MB for primitive longs!!!

  ;; also allocated-bytes reports less than before
  (allocated-bytes (fn [] (coll-of-size 1000000)))
  ;; => 54608176
```

For larger integers, primitives are clearly in advantage:

```
  ;; Now, if we increase max-val-size we got more natural results
  (deftype SomeType [^long a])
  (print-memory-layout (coll-of-size 1000000 10000))
  ;; java.util.ArrayList@6cfd8b34d footprint:
  ;;      COUNT       AVG       SUM   DESCRIPTION
  ;;          1   4861968   4861968   [Ljava.lang.Object;
  ;;    1000000        24  24000000   clojure_experiments.performance.memory.SomeType
  ;;          1        24        24   java.util.ArrayList
  ;;    1000002            28861992   (total)

  (allocated-bytes (fn [] (coll-of-size 1000000 10000)))
  ;; => 86301384

  (deftype SomeType [a])
  (print-memory-layout (coll-of-size 1000000 10000))
  ;; java.util.ArrayList@5c45001d footprint:
  ;;      COUNT       AVG       SUM   DESCRIPTION
  ;;          1   4861968   4861968   [Ljava.lang.Object;
  ;;    1000000        16  16000000   clojure_experiments.performance.memory.SomeType
  ;;     987317        24  23695608   java.lang.Long
  ;;          1        24        24   java.util.ArrayList
  ;;    1987319            44557600   (total)

  ;; BUT allocated-bytes still reports more for primitives than for Longs!
  (allocated-bytes (fn [] (coll-of-size 1000000 10000)))
  ;; => 78306424
```