### PR TITLE
Start flow-storm-debugger in user.clj to fix issues with Cmd+tab.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -115,8 +115,8 @@
         ;; use java.nio from Clojure: https://github.com/babashka/fs
         babashka/fs {:mvn/version "0.1.6"}
         ;; flow-storm-debugger: https://github.com/jpmonettas/flow-storm-debugger/
-        com.github.jpmonettas/flow-storm-dbg {:mvn/version "2.2.68"}
-        com.github.jpmonettas/flow-storm-inst {:mvn/version "2.2.68"}
+        com.github.jpmonettas/flow-storm-dbg {:mvn/version "2.2.114"}
+        com.github.jpmonettas/flow-storm-inst {:mvn/version "2.2.114"}
 
         ;; SubnetUtils is useful for IP range detection: https://jkoder.com/convert-cidr-notation-to-ip-range-in-java/
         ;; https://commons.apache.org/proper/commons-net/apidocs/index.html

--- a/src/user.clj
+++ b/src/user.clj
@@ -1,0 +1,9 @@
+(ns user
+  (:require [flow-storm.api :as fs-api]))
+
+;; Start FlowStorm debugger in user.clj instead of from the REPL or clj buffer later
+;; This fixes the problem with being unable to switch to FlowStorm window via Cmd+Tab
+;; See https://clojurians.slack.com/archives/C03KZ3XT0CF/p1658370905532999?thread_ts=1658305276.475879&cid=C03KZ3XT0CF
+(println "Starting FlowStorm debugger on thread: " (.getName (Thread/currentThread)))
+(fs-api/local-connect)
+


### PR DESCRIPTION
When started later from the REPL, the gui window wasn't available via Cmd+Tab.
It was because the thread running the REPL session isn't "main",
but nrepl thread:
```
(.getName (Thread/currentThread))
"nREPL-session-aa484f0e-2887-402c-9de3-fb5bbc852894"
```

By putting it in user.clj it's executed by Clojure itself early
and in the main thread.