### PR TITLE
How to add git commit sha to uberjar's MANIFEST.mf via leininigen.

### DIFF
--- a/project.clj.archived
+++ b/project.clj.archived
@@ -255,6 +255,8 @@
              ;; for helpful NPE messages: https://openjdk.java.net/jeps/358
              "-XX:+ShowCodeDetailsInExceptionMessages"]
   :main ^:skip-aot clojure-experiments.core
+  ;; example of how to add project's git commit sha to uberjar's manifest
+  :manifest {"git-commit-sha" ~(fn [_project] (:out (clojure.java.shell/sh "git" "rev-list" "head" "-1")))}
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}
              ;; notice sources for development!


### PR DESCRIPTION
```
  :manifest {"git-commit-sha" ~(fn [_project] (:out (clojure.java.shell/sh "git" "rev-list" "head" "-1")))}
```

See https://clojurians.slack.com/archives/C053AK3F9/p1658906829181319
and https://gitlab.com/technomancy/leiningen/blob/master/sample.project.clj#L455-459.

here I learned about :manifest key: https://ask.clojure.org/index.php/10827/ability-customize-manifest-created-clojure-tools-build-uber