### PR TITLE
Check if clj-memory-meter 0.2.0 fixes the problem with JDK 17+.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -34,7 +34,7 @@
         com.clojure-goes-fast/clj-java-decompiler {:mvn/version "0.3.1"}
         com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.0.0"}
         com.clojure-goes-fast/jvm-hiccup-meter {:mvn/version "0.1.1"}
-        com.clojure-goes-fast/clj-memory-meter {:mvn/version "0.1.3"}
+        com.clojure-goes-fast/clj-memory-meter {:mvn/version "0.2.0"}
         com.clojure-goes-fast/jvm-alloc-rate-meter {:mvn/version "0.1.4"}
         criterium/criterium {:mvn/version "0.4.6"}
         org.clojars.pntblnk/clj-ldap {:mvn/version "0.0.17"}

--- a/src/clojure_experiments/collections/collections.clj
+++ b/src/clojure_experiments/collections/collections.clj
@@ -585,8 +585,16 @@ db
 ;; => {1 11, 2 21}
 (type (update-vals (sorted-map 1 10 2 20) inc))
 ;; => clojure.lang.PersistentArrayMap
+
+(sorted-map 1 10 2 20 3 30 4 40 5 50 6 60 7 70 8 80 9 90)
+;; => {1 10, 2 20, 3 30, 4 40, 5 50, 6 60, 7 70, 8 80, 9 90}
 (type (sorted-map 1 10 2 20 3 30 4 40 5 50 6 60 7 70 8 80 9 90))
 ;; => clojure.lang.PersistentTreeMap
+(update-vals (sorted-map 1 10 2 20 3 30 4 40 5 50 6 60 7 70 8 80 9 90) inc)
+;; => {7 71, 1 11, 4 41, 6 61, 3 31, 2 21, 9 91, 5 51, 8 81}
 (type (update-vals (sorted-map 1 10 2 20 3 30 4 40 5 50 6 60 7 70 8 80 9 90) inc))
 ;; => clojure.lang.PersistentHashMap
 
+(update-keys (sorted-map 1 10 2 20 3 30 4 40 5 50 6 60 7 70 8 80 9 90) inc)
+
+(transient (sorted-map 1 10 2 20))

--- a/src/clojure_experiments/performance/memory.clj
+++ b/src/clojure_experiments/performance/memory.clj
@@ -322,8 +322,40 @@
 ;;        166                3616   (total)
 
 
-  ;; doesn't work with JDK 17 (breaks module encapsulation: see https://stackoverflow.com/questions/69753263/unable-to-make-field-final-transient-java-lang-class-java-util-enumset-elementty)
-  #_(mm/measure coll :bytes true)
+  ;; doesn't work with JDK 17 (breaks module encapsulation:
+  ;; - https://github.com/clojure-goes-fast/clj-memory-meter/issues/8#issuecomment-1196407536
+  ;; - https://stackoverflow.com/questions/69753263/unable-to-make-field-final-transient-java-lang-class-java-util-enumset-elementty)
+  #_(mm/measure (coll-of-size 100) :bytes true)
+
+  ;; ... still broken even in clj-memory-meter 0.2.0: https://github.com/clojure-goes-fast/clj-memory-meter/issues/8#issuecomment-1196407536
+  #_(mm/measure (coll-of-size 100) :bytes true)
+;;   1. Caused by java.lang.reflect.InaccessibleObjectException
+;;    Unable to make field transient java.lang.Object[] java.util.ArrayList.elementData accessible:
+;;    module java.base does not "opens java.util" to unnamed module @29ff01df
+
+;;      AccessibleObject.java:  387  java.lang.reflect.AccessibleObject/throwInaccessibleObjectException
+;;      AccessibleObject.java:  363  java.lang.reflect.AccessibleObject/checkCanSetAccessible
+;;      AccessibleObject.java:  311  java.lang.reflect.AccessibleObject/checkCanSetAccessible
+;;                 Field.java:  180  java.lang.reflect.Field/checkCanSetAccessible
+;;                 Field.java:  174  java.lang.reflect.Field/setAccessible
+;;       MemoryMeterBase.java:  273  org.github.jamm.MemoryMeterBase/declaredClassFields0
+;;       MemoryMeterBase.java:   15  org.github.jamm.MemoryMeterBase/access$000
+;;       MemoryMeterBase.java:   24  org.github.jamm.MemoryMeterBase$1/computeValue
+;;       MemoryMeterBase.java:   20  org.github.jamm.MemoryMeterBase$1/computeValue
+;;            ClassValue.java:  229  java.lang.ClassValue/getFromHashMap
+;;            ClassValue.java:  211  java.lang.ClassValue/getFromBackup
+;;            ClassValue.java:  117  java.lang.ClassValue/get
+;;       MemoryMeterBase.java:  246  org.github.jamm.MemoryMeterBase/declaredClassFields
+;;       MemoryMeterBase.java:  145  org.github.jamm.MemoryMeterBase/measureDeep
+;; DirectMethodHandleAccessor.java:  104  jdk.internal.reflect.DirectMethodHandleAccessor/invoke
+;;                Method.java:  578  java.lang.reflect.Method/invoke
+;;             Reflector.java:  167  clojure.lang.Reflector/invokeMatchingMethod
+;;             Reflector.java:  102  clojure.lang.Reflector/invokeInstanceMethod
+;;                   core.clj:  166  clj-memory-meter.core/measure
+;;                   core.clj:  150  clj-memory-meter.core/measure
+;;                RestFn.java:  439  clojure.lang.RestFn/invoke
+;;                       REPL:  330  clojure-experiments.performance.memory/eval22393
+
 
 
   ;; with type hint (primitives) it looks consistent


### PR DESCRIPTION
no, it doesn't :(.