### PR TITLE
Add my own version of `locals` macro.

### DIFF
--- a/src/clojure_experiments/debugging.clj
+++ b/src/clojure_experiments/debugging.clj
@@ -35,6 +35,7 @@
   ;; will run the debbuger GUI and get everything ready
   (fs-api/local-connect)
 
+
   #rtrace (reduce + (map inc (range 10)))
 
   #rtrace (foo 3)
@@ -44,6 +45,8 @@
   #trace
   (defn factorial [n]
     (if (zero? n) 1 (* n (factorial (dec n)))))
+
+  
 
   #rtrace
   (->> (range)
@@ -74,3 +77,11 @@
   .)
 
 
+;;; debugging macro that can save the local context
+(defmacro locals []
+  (let [ks (keys &env)]
+    `(do
+       (println "====================== DEBUG locals =======================")
+       (clojure.pprint/pprint (zipmap '~ks [~@ks]))
+       (println "====================== END DEBUG locals =======================")
+       (def my-locals (zipmap '~ks [~@ks])))))

--- a/src/clojure_experiments/experiments.clj
+++ b/src/clojure_experiments/experiments.clj
@@ -961,6 +961,14 @@ d-m
         (map (juxt (comp keyword name)
                    identity))
         (keys &env)))
+;; my version
+(defmacro locals []
+  (let [ks (keys &env)]
+    `(do
+       (println "====================== DEBUG locals =======================")
+       (clojure.pprint/pprint (zipmap '~ks [~@ks]))
+       (println "====================== END DEBUG locals =======================")
+       (def my-locals (zipmap '~ks [~@ks])))))
 
 (defn foo [x]
   (let [y (+ x x)]

--- a/src/clojure_experiments/macros/macros.clj
+++ b/src/clojure_experiments/macros/macros.clj
@@ -175,3 +175,13 @@
 ;; so recursive-macro-1 throws away all the elements but the last one!
 (recursive-macro-1 [1 2 3 4 5] [])
 ;; => [5 5 5 5 5]
+
+
+;; debugging macro that can save the local context
+(defmacro locals []
+  (let [ks (keys &env)]
+    `(do
+       (println "====================== DEBUG locals =======================")
+       (clojure.pprint/pprint (zipmap '~ks [~@ks]))
+       (println "====================== END DEBUG locals =======================")
+       (def my-locals (zipmap '~ks [~@ks])))))


### PR DESCRIPTION
This one will automatically create `my-locals` def.

```
(defmacro locals []
  (let [ks (keys &env)]
    `(do
       (println "====================== DEBUG locals =======================")
       (clojure.pprint/pprint (zipmap '~ks [~@ks]))
       (println "====================== END DEBUG locals =======================")
       (def my-locals (zipmap '~ks [~@ks])))))
```