### PR TITLE
Experiment with fulcrologic/guardrails.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -157,6 +157,11 @@
         ;; - For most use cases it will make your life much easier to use it.
         aysylu/loom {:mvn/version "1.0.2"}
 
+        ;; wrapper for ghostwheel: https://github.com/fulcrologic/guardrails
+        ;; see also https://www.fulcrologic.com/open-source#guardrails
+        ;; and "-Dguardrails.enabled" jvm option below (https://github.com/fulcrologic/guardrails#quick-start)
+        com.fulcrologic/guardrails {:mvn/version "1.1.11"}
+
         }
 
  ;; Make sure to configure this alias in `cider-clojure-cli-aliases` - see .dir-locals.el
@@ -180,4 +185,6 @@
               "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.runtime=ALL-UNNAMED"
               "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.classfile=ALL-UNNAMED"
               ;; for helpful NPE messages: https://openjdk.java.net/jeps/358
-              "-XX:+ShowCodeDetailsInExceptionMessages"]}}}
+              "-XX:+ShowCodeDetailsInExceptionMessages"
+              ;; To enable guardrails: https://github.com/fulcrologic/guardrails#quick-start
+              "-Dguardrails.enabled"]}}}

--- a/guardrails.edn
+++ b/guardrails.edn
@@ -1,0 +1,2 @@
+;; see https://github.com/fulcrologic/guardrails/#configuration
+{}

--- a/src/clojure_experiments/java.clj
+++ b/src/clojure_experiments/java.clj
@@ -96,6 +96,16 @@
 ;;     [true true]
 ;;     [clojure_experiments.java.proxy$java.util.zip.ZipFile$ff19274a java.util.zip.ZipFile]]
 
+;; the minimal implementation would be
+(let [filename "empty.zip"
+      original-zip (ZipFile. filename)
+      proxy-zip (proxy [ZipFile] [filename]
+                  ;; overriding close method
+                  (close [] (println "Ignored!")))]
+  [[(.getName proxy-zip) (.getName original-zip)]
+   ;; check the REPL - you will see "Ignored!" printed one time
+   [(.close proxy-zip) (.close original-zip)]])
+
 
 ;; ... or use lesser-known `get-proxy-class`, `construct-proxy`, and `init-proxy`
 ;; (later you could also use `update-proxy`)

--- a/src/clojure_experiments/macros/macros.clj
+++ b/src/clojure_experiments/macros/macros.clj
@@ -198,7 +198,7 @@
   (inspect []))
 
 ;; For mutable fields, see https://stackoverflow.com/questions/3132931/mutable-fields-in-clojure-deftype
-(deftype cfg [^:volatile-mutable maxTotal
+(deftype Cfg [^:volatile-mutable maxTotal
               ^:volatile-mutable maxIdle
               ^:volatile-mutable maxWait]
   ICfg
@@ -207,7 +207,7 @@
   (setMaxWait [this max] (set! maxWait max))
   (inspect [this] [maxTotal maxIdle maxWait]))
 
-(def my-config (->cfg 0 0 0))
+(def my-config (->Cfg 0 0 0))
 (.inspect my-config)
 ;; => [0 0 0]
 
@@ -278,4 +278,5 @@
           max-wait-ms (.setMaxWait max-wait-ms)))
 (.inspect my-config)
 ;; => [1000000 2 10]
+
 

--- a/src/clojure_experiments/specs/guardrails.clj
+++ b/src/clojure_experiments/specs/guardrails.clj
@@ -1,0 +1,77 @@
+(ns clojure-experiments.specs.guardrails
+  "See https://github.com/fulcrologic/guardrails#quick-start
+  and https://www.fulcrologic.com/open-source#guardrails"
+  (:require
+   [clojure.spec.alpha :as s]
+   [com.fulcrologic.guardrails.core :refer [>def >defn]]))
+
+;; >def is spec that's only used in development and removed from production builds
+;; see `com.fulcrologic.guardrails.noop`
+(>def ::thing (s/or :i int? :s string?))
+(>defn f
+       [i]
+       [::thing => int?]
+       (if (string? i) 0 (inc i)))
+
+(f 10)
+;; => 11
+(f "10")
+;; => 0
+
+;; now try it with an invalid argument type
+(comment
+  (f {:i 10})
+  ;; WARNING: the error reporting might collide with stest/expound itself
+  ;; - this happens when you call `(clojure.spec.test.alpha/instrument)`
+  ;;   which my cider load buffer implementation does by default.
+  ;; so if you load the whole buffer you will see this exception and it fails
+  ;; without actually calling the body of `f`
+  ;; Spec assertion failed.
+  ;;
+  ;; Spec: #object[clojure.spec.alpha$regex_spec_impl$reify__2503 0x173f13c8 "clojure.spec.alpha$regex_spec_impl$reify__2503@173f13c8"]
+  ;; Value: ({:i 10})
+  ;;
+  ;; Problems: 
+  ;;
+  ;; val: {:i 10}
+  ;; in: [0]
+  ;; failed: int?
+  ;; spec: :clojure-experiments.specs.guardrails/thing
+  ;; at: [:i :i]
+  ;;
+  ;; val: {:i 10}
+  ;; in: [0]
+  ;; failed: string?
+  ;; spec: :clojure-experiments.specs.guardrails/thing
+  ;; at: [:i :s]
+
+
+  ;; but if you only eval `f` and then run this again you see ClassCastException
+  (f {:i 10})
+
+  ;; => throws exception (by default, the failure doesn't stop the implementation)
+  ;; 1. Unhandled java.lang.ClassCastException
+  ;; class java.lang.Object cannot be cast to class java.lang.Number (java.lang.Object and
+  ;;   java.lang.Number are in module java.base of loader 'bootstrap')
+  ;;
+  ;; ... and print's nice error on stdout:
+  ;; .../src/clojure_experiments/specs/guardrails.clj:11 f's argument list
+  ;; -- Spec failed --------------------
+  ;;
+  ;;   [#object[java.lang.Object 0x1bea1137 "java.lang.Object@1bea1137"]]
+  ;;   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ;;
+  ;; should satisfy
+  ;; 
+  ;;   int?
+  ;; 
+  ;; or
+  ;; 
+  ;;   string?
+  ;;
+  ;; -- Relevant specs -------
+  ;;
+  ;; :clojure-experiments.specs.guardrails/thing:
+  ;;   (clojure.spec.alpha/or :i clojure.core/int? :s clojure.core/string?)
+
+  .)


### PR DESCRIPTION
It improves a bit fdef spec definition and error reporting,
although the reporting part seems to be well covered by expound itself.
However, it can also turn off the eager spec checking by default
(but you cannot call `clojure.spec.test.alpha/instrument`,
otherwise the standard spec instrumention machinery kicks in).