### PR TITLE
Clojure brain teasers: 09 - needle in the haystack.

### DIFF
--- a/src/clojure_experiments/books/clojure_brain_teasers/09_haystack.clj
+++ b/src/clojure_experiments/books/clojure_brain_teasers/09_haystack.clj
@@ -1,0 +1,28 @@
+(ns clojure-experiments.books.clojure-brain-teasers.09-haystack)
+
+(def haystack
+  (shuffle (conj (range 100) :needle)))
+(contains? haystack :needle)
+;; => false
+
+;; that's because haystack is a list/vector
+(type haystack)
+;; => clojure.lang.PersistentVector
+(some #(= :haystack %) haystack)
+(contains? haystack 19)
+;; => true
+(get haystack 19) ; the index of the ':needle' element will be different every time because of `shuffle`
+;; => :needle
+
+
+;;; Ok, but how to find it??
+
+;; maybe use a set
+(contains? (set haystack) :needle)
+;; => true
+
+;; at worst, linear search
+(some #{:needle} haystack) ; NOTE: some doesn't use a chunked sequence so it's lazier than `filter` below
+;; => :needle
+(first (filter #{:needle} haystack))
+;; => :needle


### PR DESCRIPTION
A few ways to find an element in a vector:
```
(contains? (set haystack) :needle)
;; => true

;; at worst, linear search
(some #{:needle} haystack) ; NOTE: some doesn't use a chunked sequence so it's lazier than `filter` below
;; => :needle
(first (filter #{:needle} haystack))
;; => :needle
```