### PR TITLE
Clojure brainteasers: 17 - threading macros.

### DIFF
--- a/src/clojure_experiments/books/clojure_brain_teasers/03_nan.clj
+++ b/src/clojure_experiments/books/clojure_brain_teasers/03_nan.clj
@@ -13,3 +13,11 @@
 
 (/ 0.0 0.0)
 ;; => ##NaN
+
+;;; BONUS:
+
+(/ 1 0.0)
+;; => ##Inf
+(/ 1 0)
+;; => 1. Unhandled java.lang.ArithmeticException
+

--- a/src/clojure_experiments/books/clojure_brain_teasers/17_loose-threads.clj
+++ b/src/clojure_experiments/books/clojure_brain_teasers/17_loose-threads.clj
@@ -1,0 +1,29 @@
+(ns clojure-experiments.books.clojure-brain-teasers.17-loose-threads
+  "https://clojure.org/guides/threading_macros")
+
+
+(-> 10 inc) ;; => 11
+
+(-> 10 #(+ % 1))
+;;    class java.lang.Long cannot be cast to class clojure.lang.ISeq
+
+;;; Explanation:
+;; 1. The anonymous function gets rewritten to `fn`
+;; - this is the expression that the the macro sees
+'(fn [x] (+ x 1))
+;; 2. thread macro reorganizes the code into:
+'(fn 10 [x] (+ x 1))
+
+
+;;; Fixes
+;; 1.Wrap anonymous function with extra parens
+(-> 10 (#(+ % 1))) ;; => 11
+;; NOTE: this is effectively the following
+((fn [x] (+ x 1)) 10) ;; => 11
+
+;; 2. Better: use `as->`
+(as-> 10 $ (+ $ 1));; => 11
+;; BUT come one! this is the same as the following!
+(-> 10 (+ 1))
+;; => 11
+


### PR DESCRIPTION
https://clojure.org/guides/threading_macros

Interesting explanation of how anonymous function literal expands into `(fn ...)` and why this breaks with ->.

```
(-> 10 #(+ % 1))
;;    class java.lang.Long cannot be cast to class clojure.lang.ISeq

;;; Explanation:
;; 1. The anonymous function gets rewritten to `fn`
;; - this is the expression that the the macro sees
'(fn [x] (+ x 1))
;; 2. thread macro reorganizes the code into:
'(fn 10 [x] (+ x 1))
```